### PR TITLE
First pass on XWP code challenge which addresses various security, performance, readability, and code standard improvements to the Site Counts block

### DIFF
--- a/php/Block.php
+++ b/php/Block.php
@@ -187,8 +187,8 @@ class Block {
 					'post__in'       => $posts_list_query_post_ids,
 					'post_type'      => [ 'post', 'page' ], // Post types need to match the original query.
 					'fields'         => 'ids',
-				    'orderby'        => 'post__in', // Ensure proper order is maintained.
-				    'posts_per_page' => count( $posts_list_query_post_ids ), // Ensure all ids are used.
+					'orderby'        => 'post__in', // Ensure proper order is maintained.
+					'posts_per_page' => count( $posts_list_query_post_ids ), // Ensure all ids are used.
 				]
 			);
 		}

--- a/php/Block.php
+++ b/php/Block.php
@@ -249,8 +249,14 @@ class Block {
 				<h2><?php
 					echo esc_html(
 						sprintf(
-							__( '%1$d posts with the tag of foo and the category of baz', 'site-counts' ),
-							absint( $posts_list_query->found_posts )
+							__( '%1$d %2$s with the tag of foo and the category of baz', 'site-counts' ),
+							absint( $posts_list_query->found_posts ),
+							_n(
+								'post',
+								'posts',
+								absint( $posts_list_query->found_posts ),
+								'site-counts'
+							)
 						)
 					);
 				?></h2>


### PR DESCRIPTION
## Summary
This pull request contains a number of updates to the `render_block()` logic for the Site Counts block.

## Notes for reviewers
- This PR includes additional inline comments which would be helpful for developers looking at this code later.
- This PR also includes comments within Github that outline my thinking for historical context, as if I was actually doing a pull request and code review.
- I use `esc_html()` along with `sprintf()` in a few places. I'm assuming we don't need to support html markup in the translations, but this could be replaced with `wp_kses_post()` if needed.
- This method is still very monolithic. For the sake of this challenge I wanted to keep it all within `render_block()`, but all of this logic needs to be broken up into methods to disentangle the data fetching/formatting logic from the view/templating logic.
- I'm a stickler for validating data before using it all, to the point where it can seem a bit outrageous, but it really cuts down on production bugs when (inevitably) something unexpected happens. I would normally use type hinting to help achieve this, but I believe there are mixed opinions on the subject, so I didn't want to take it too far.

Thank you for your time reviewing this PR.